### PR TITLE
Fix tab background to be transparent in IE11, instead of blue

### DIFF
--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -11,6 +11,7 @@
   .tab {
     color: $frost-color-grey-5;
     padding-bottom: 5px;
+    background-color: transparent;
   }
 
   .tab.tertiary:hover {

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "ember-frost-tabs",
   "version": "0.1.3",
   "description": "The default blueprint for ember-cli addons.",
+  "frostGuideDirectory" : "ui-components/content-views/tabs",
   "directories": {
     "doc": "doc",
     "test": "tests"


### PR DESCRIPTION
# minor#

In IE11 the frost tab background is $frost-color-blue-1. Changed it to transparent and ran a regression test on all other browsers to ensure the look is still the same
