### PR TITLE
Override box-shadow and border from frost-button

### DIFF
--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -26,6 +26,16 @@
     color: $frost-color-grey-2;
     border-bottom: 5px solid $frost-color-blue-1;
   }
+  
+  .tab.frost-button.tertiary:focus {
+    border-left: 0;
+    border-top: 0;
+    border-right: 0;
+  }
+
+  .tab.frost-button:focus {
+    box-shadow: none;
+  }
   }
 
   > .content.hidden {


### PR DESCRIPTION
# fix

remove glow around focused frost-tab 

![frost-tabsglow](https://cloud.githubusercontent.com/assets/11548575/13922904/b946cc62-ef54-11e5-934a-125fed31a7c3.png)
