### PR TITLE
use text property with tab design

### DIFF
--- a/addon/pods/components/frost-tabs/template.hbs
+++ b/addon/pods/components/frost-tabs/template.hbs
@@ -1,9 +1,6 @@
 <div class="tab-nav">
   {{#each tabs as |tab|}}
-    {{#frost-button class=(concat 'tab' (if (eq tab.id selection) ' active')) design='tab' disabled=tab.disabled onClick=(action on-change tab.id)}}
-            <div class="text">
-        {{tab.alias}}
-            </div>
+    {{#frost-button class=(concat 'tab' (if (eq tab.id selection) ' active')) design='tab' disabled=tab.disabled onClick=(action on-change tab.id) text=tab.alias}}
     {{/frost-button}}
   {{/each}}
 </div>


### PR DESCRIPTION
# fix

meet frost-button expectations

```
// design button needs to have either text or icon property present
        if (this.get('text') === '' && this.get('icon') === '') {
          _ember['default'].Logger.error('Error: The `design` property requires `text` or `icon` property to be specified.');
          return;
        }
```

Also note that without this fix, the tabs don't switch in Firefox when clicking the text.
