### PR TITLE
Fix Ember 2.6.0 deprecation

### DIFF
--- a/addon/pods/components/frost-tab/component.js
+++ b/addon/pods/components/frost-tab/component.js
@@ -9,7 +9,8 @@ export default Ember.Component.extend({
 
   frostTabs: null,
 
-  didInitAttrs () {
+  init () {
+    this._super(...arguments)
     this.set('frostTabs', this.nearestOfType(FrostTabs))
     this.get('frostTabs').register(this)
   },

--- a/addon/pods/components/frost-tabs/component.js
+++ b/addon/pods/components/frost-tabs/component.js
@@ -7,7 +7,8 @@ export default Ember.Component.extend({
 
   tabs: [],
 
-  didInitAttrs () {
+  init () {
+    this._super(...arguments)
     this.set('tabs', [])
   },
 

--- a/bower.json
+++ b/bower.json
@@ -9,7 +9,8 @@
     "Faker": "^3.0.1",
     "jquery": "2.1.4",
     "lodash": "^3.10.1",
-    "pretender": "^0.10.1"
+    "pretender": "^0.10.1",
+    "perfect-scrollbar": ">=0.6.7 <2.0.0"
   },
   "resolutions": {
     "ember": "2.4.1"

--- a/package.json
+++ b/package.json
@@ -48,8 +48,8 @@
     "ember-resolver": "^2.0.3",
     "ember-truth-helpers": "^1.2.0",
     "ember-try": "^0.2.0",
-    "eslint": "2.2.0",
-    "eslint-config-frost-standard": "^1.0.0",
+    "eslint": "^2.11.1",
+    "eslint-config-frost-standard": "^2.0.0",
     "loader.js": "^4.0.1"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.2",
+    "ember-browserify": "1.1.9",
     "ember-cli": "^2.3.0",
     "ember-cli-app-version": "^1.0.0",
     "ember-cli-blanket": "0.9.1",
@@ -39,18 +40,21 @@
     "ember-cli-mocha": "^0.10.0",
     "ember-cli-notifications": "^3.2.0",
     "ember-cli-uglify": "^1.2.0",
+    "ember-computed-decorators": "0.2.2",
     "ember-data": "^2.3.3",
     "ember-disable-proxy-controllers": "^1.0.1",
     "ember-export-application-global": "^1.0.5",
     "ember-frost-core": ">=0.0.14 <2.0.0",
     "ember-load-initializers": "^0.5.1",
-    "ember-lodash": "^0.0.6",
+    "ember-lodash": "0.0.7",
+    "ember-one-way-controls": "0.8.2",
     "ember-resolver": "^2.0.3",
     "ember-truth-helpers": "^1.2.0",
     "ember-try": "^0.2.0",
     "eslint": "^2.11.1",
     "eslint-config-frost-standard": "^2.0.0",
-    "loader.js": "^4.0.1"
+    "loader.js": "^4.0.1",
+    "svg4everybody": "2.0.3"
   },
   "keywords": [
     "ember-addon",

--- a/tests/dummy/app/app.js
+++ b/tests/dummy/app/app.js
@@ -1,6 +1,6 @@
 import Ember from 'ember'
-import Resolver from 'ember/resolver'
-import loadInitializers from 'ember/load-initializers'
+import Resolver from 'ember-resolver'
+import loadInitializers from 'ember-load-initializers'
 import config from './config/environment'
 
 let App

--- a/tests/helpers/resolver.js
+++ b/tests/helpers/resolver.js
@@ -1,4 +1,4 @@
-import Resolver from 'ember/resolver'
+import Resolver from 'ember-resolver'
 import config from '../../config/environment'
 
 const resolver = Resolver.create()


### PR DESCRIPTION
# PATCH
# CHANGELOG
- **Fixed** deprecation warning from Ember 2.6.0 to stop using `didInitAttrs` hook and instead use `init`.
