### PR TITLE
Tab content classnames

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ env:
 matrix:
   fast_finish: true
   allow_failures:
+  - env: EMBER_TRY_SCENARIO=ember-beta
   - env: EMBER_TRY_SCENARIO=ember-canary
 before_install:
 - npm config set spin false

--- a/README.md
+++ b/README.md
@@ -24,6 +24,21 @@ See the demo application for usage information.
 
 * `ember install ember-frost-tabs`
 
+## Component APIs
+
+### Frost-tabs
+| Attribute   | Type       | Required | Description                    |
+| ----------- | ---------- | -------- | ----------------------------------------------------- |
+| `onChange`  | `Function` | Yes      | Function called when tab is changed with the tab's ID |
+| `selection` | `String`   | No       | The selected tab                                      |
+
+### Frost-tab
+| Attribute       | Type     | Required | Description                                         |
+| --------------- | -------- | -------- | --------------------------------------------------- |
+| `id`            | `String` | Yes      | The tab's ID (should be unique from other tabs)     |
+| `alias`         | `String` | Yes      | Label for the tab                                   |
+| `tabClassNames` | `String` | No       | CSS class string to apply to the tab's content area |
+
 ## Example
 ### Template
 ```handlebars
@@ -82,4 +97,4 @@ visit the app at http://localhost:4200.
 
 ### Testing
 Run `npm test` from the root of the project to run linting checks as well as execute the test suite
-and output code coverage. 
+and output code coverage.

--- a/addon/pods/components/frost-tab/component.js
+++ b/addon/pods/components/frost-tab/component.js
@@ -5,7 +5,7 @@ import FrostTabs from 'ember-frost-tabs/pods/components/frost-tabs/component'
 export default Ember.Component.extend({
   layout: layout,
   classNames: ['content'],
-  classNameBindings: ['isSelected::hidden'],
+  classNameBindings: ['isSelected::hidden', 'tabClassNames'],
 
   frostTabs: null,
 

--- a/tests/dummy/app/pods/demo/template.hbs
+++ b/tests/dummy/app/pods/demo/template.hbs
@@ -1,10 +1,10 @@
 <div class='ember-frost-demo'>
 {{#frost-tabs onChange=(action 'demoTabSelected') selection=demoTabSelected}}
-  {{#frost-tab alias='Template' id='template'}}
+  {{#frost-tab alias='Template' id='template' tabClassNames='some-tab-class'}}
       <div id='content'>
   <pre><code>
     \{{#frost-tabs frostTabs=tabs}}
-    \{{#frost-tab alias='Template' id='template'}}
+    \{{#frost-tab alias='Template' id='template' tabClassNames='some-tab-class'}}
       ...
     \{{/frost-tab}}
     \{{#frost-tab alias='Controller' id='controller'}}

--- a/tests/integration/components/frost-tabs-test.js
+++ b/tests/integration/components/frost-tabs-test.js
@@ -94,5 +94,35 @@ describeComponent(
       Ember.run(() => $('.frost-button').get(0).click())
       expect(this.get('selectedTab')).to.eql('template')
     })
+
+    it('gives tab content a specified css class', function () {
+      this.set('selectedTab', 'template')
+      this.on('tabSelected', function (tab) {
+        this.set('selectedTab', tab)
+      })
+      this.render(hbs`
+        {{#frost-tabs onChange=(action 'tabSelected') selection=selectedTab}}
+          {{#frost-tab alias='Template' id='template' tabClassNames='template-class-name'}}
+            <div id='content'>
+              Template
+            </div>
+          {{/frost-tab}}
+          {{#frost-tab alias='Controller' id='controller' tabClassNames='controller-class-name'}}
+            <div id='content'>
+              controller
+            </div>
+          {{/frost-tab}}
+          {{#frost-tab alias='CSS' disabled=true id='css' tabClassNames='css-class-name'}}
+            <div id='content'>
+              css
+            </div>
+          {{/frost-tab}}
+        {{/frost-tabs}}
+      `)
+
+      expect(this.$('.template-class-name')).to.have.length(1)
+      expect(this.$('.controller-class-name')).to.have.length(1)
+      expect(this.$('.css-class-name')).to.have.length(1)
+    })
   }
 )


### PR DESCRIPTION
# MINOR
# CHANGELOG
- Added `tabClassNames` to `frost-tab` interface to allow for specifying CSS classes on tab content elements.
