### PR TITLE
Add ember-simple-uuid to blueprint

### DIFF
--- a/blueprints/ember-frost-tabs/index.js
+++ b/blueprints/ember-frost-tabs/index.js
@@ -11,7 +11,8 @@ module.exports = {
   afterInstall: function () {
     return this.addAddonsToProject({
       packages: [
-        {name: 'ember-frost-core', target: '^0.29.0'}
+        {name: 'ember-frost-core', target: '^0.29.0'},
+        {name: 'ember-simple-uuid', target: '0.1.4'}
       ]
     })
   }


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change
# CHANGELOG
- **Added** missing dependencies from blueprints.
