### PR TITLE
Support for a content class per tab

### DIFF
--- a/addon/pods/components/frost-tab/component.js
+++ b/addon/pods/components/frost-tab/component.js
@@ -22,6 +22,7 @@ export default Component.extend(PropTypesMixin, {
       PropTypes.EmberObject,
       PropTypes.object
     ]).isRequired,
+    contentClass: PropTypes.string,
     disabled: PropTypes.bool,
     // Set by the parent component
     hook: PropTypes.string,

--- a/addon/pods/components/frost-tab/template.hbs
+++ b/addon/pods/components/frost-tab/template.hbs
@@ -11,6 +11,7 @@
   {{to-elsewhere
     named=targetOutlet
     send=(hash
+      contentClass=contentClass
       content=content
     )
   }}

--- a/addon/pods/components/frost-tabs/template.hbs
+++ b/addon/pods/components/frost-tabs/template.hbs
@@ -11,14 +11,19 @@
   {{else}}
     {{#each tabs as |tab index|}}
       <div data-test={{hook (concat hook '-tab') index=index}}>
-        {{component tab parentHook=hook targetOutlet=targetOutlet selectedTab=selectedTab onChange=onChange}}
+        {{component tab
+          parentHook=hook
+          selectedTab=selectedTab
+          targetOutlet=targetOutlet
+          onChange=onChange
+        }}
       </div>
     {{/each}}
   {{/if}}
 </div>
 
-<div class='content' data-test={{hook (concat hook '-tab-content')}}>
-  {{#from-elsewhere name=targetOutlet as |tab|}}
+{{#from-elsewhere name=targetOutlet as |tab|}}
+  <div class='content {{tab.contentClass}}' data-test={{hook (concat hook '-tab-content')}}>
     {{component tab.content}}
-  {{/from-elsewhere}}
-</div>
+  </div>
+{{/from-elsewhere}}

--- a/tests/dummy/app/pods/demo/content/template.hbs
+++ b/tests/dummy/app/pods/demo/content/template.hbs
@@ -52,7 +52,9 @@
         (component 'frost-tab'
           id='template'
           text='Template'
-          content=(component 'tab-content' text='template'))
+          content=(component 'tab-content' text='template')
+          contentClass='foo'
+        )
         (component 'frost-tab'
           id='controller'
           text='Controller'


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
- [ ] #patch# - backwards-compatible bug fix
- [x] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change
# CHANGELOG
- Added a contentClass property to `frost-tab` that appends to the `content` div when that tab is selected
