### PR TITLE
Update usage of deprecated ember-mocha describeComponent()

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "ember-simple-uuid": "0.1.4",
     "ember-sinon": "0.6.0",
     "ember-spread": "^1.1.1",
+    "ember-test-utils": "1.7.0",
     "ember-truth-helpers": "^1.3.0",
     "eslint": "^3.14.0",
     "eslint-config-frost-standard": "^5.3.2",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "ember-simple-uuid": "0.1.4",
     "ember-sinon": "0.6.0",
     "ember-spread": "^1.1.1",
-    "ember-test-utils": "1.7.0",
+    "ember-test-utils": "^1.7.0",
     "ember-truth-helpers": "^1.3.0",
     "eslint": "^3.14.0",
     "eslint-config-frost-standard": "^5.3.2",

--- a/tests/integration/components/frost-tab-test.js
+++ b/tests/integration/components/frost-tab-test.js
@@ -1,9 +1,8 @@
 import {expect} from 'chai'
 import {$hook, initialize} from 'ember-hook'
-import {describeComponent} from 'ember-mocha'
 import wait from 'ember-test-helpers/wait'
 import hbs from 'htmlbars-inline-precompile'
-import {beforeEach, it} from 'mocha'
+import {beforeEach, describe, it} from 'mocha'
 
 const frostTabHook = '-tab'
 const hookName = 'my-hook'
@@ -32,124 +31,122 @@ const template = hbs`
   </div>
 `
 
-describeComponent(
-  'frost-tab',
-  'Integration: FrostTabComponent',
-  {
-    integration: true
-  },
-  function () {
-    beforeEach(function () {
-      initialize()
-      this.setProperties({
-        onChange,
-        tabId,
-        tabText,
-        targetOutlet
-      })
+import {integration} from 'dummy/tests/helpers/ember-test-utils/setup-component-test'
+
+const test = integration('frost-tab')
+describe(test.label, function () {
+  test.setup()
+
+  beforeEach(function () {
+    initialize()
+    this.setProperties({
+      onChange,
+      tabId,
+      tabText,
+      targetOutlet
     })
+  })
 
-    it('Renders', function (done) {
-      this.setProperties({
-        selectedTab: tabId
-      })
-      this.render(template)
-      return wait()
-        .then(() => {
-          expect($hook(`${frostTabHook}`, {selected: true})).to.have.length(1)
-          expect($hook(`${frostTabHook}`, {selected: true}).find('button.active')).to.have.length(1)
-          expect($hook('content').text().trim()).to.be.equal(tabText)
+  it('Renders', function (done) {
+    this.setProperties({
+      selectedTab: tabId
+    })
+    this.render(template)
+    return wait()
+      .then(() => {
+        expect($hook(`${frostTabHook}`, {selected: true})).to.have.length(1)
+        expect($hook(`${frostTabHook}`, {selected: true}).find('button.active')).to.have.length(1)
+        expect($hook('content').text().trim()).to.be.equal(tabText)
 
-          return capture('frost-tab', done, {
-            experimentalSvgs: true
-          })
+        return capture('frost-tab', done, {
+          experimentalSvgs: true
         })
-    })
-
-    it('No tab selected', function () {
-      this.render(template)
-
-      return wait()
-        .then(() => {
-          expect($hook(`${frostTabHook}`, {selected: false})).to.have.length(1)
-          expect($hook(`${frostTabHook}`, {selected: true})).to.have.length(0)
-          expect($hook(`${frostTabHook}`, {selected: true}).find('button.active')).to.have.length(0)
-        })
-    })
-
-    it('Selected tab', function () {
-      this.setProperties({
-        selectedTab: tabId
       })
-      this.render(template)
+  })
 
-      return wait()
-        .then(() => {
-          expect($hook('content').text().trim()).to.be.equal(tabText)
-        })
-    })
+  it('No tab selected', function () {
+    this.render(template)
 
-    it('Disabled', function () {
-      this.setProperties({
-        disabled: true
+    return wait()
+      .then(() => {
+        expect($hook(`${frostTabHook}`, {selected: false})).to.have.length(1)
+        expect($hook(`${frostTabHook}`, {selected: true})).to.have.length(0)
+        expect($hook(`${frostTabHook}`, {selected: true}).find('button.active')).to.have.length(0)
       })
-      this.render(template)
+  })
 
-      return wait()
-        .then(() => {
-          expect($hook(`${frostTabHook}`)).to.have.length(1)
-          expect($hook(`${frostTabHook}`).find('button.disabled')).to.have.length(1)
-        })
+  it('Selected tab', function () {
+    this.setProperties({
+      selectedTab: tabId
     })
+    this.render(template)
 
-    it('Set parent hook', function () {
-      this.setProperties({
-        selectedTab: tabId,
-        hookName: hookName
+    return wait()
+      .then(() => {
+        expect($hook('content').text().trim()).to.be.equal(tabText)
       })
-      this.render(template)
+  })
 
-      return wait()
-        .then(() => {
-          expect($hook(`${hookName}${frostTabHook}`, {selected: true})).to.have.length(1)
-          expect($hook(`${hookName}${frostTabHook}`, {selected: true}).find('button.active')).to.have.length(1)
-        })
+  it('Disabled', function () {
+    this.setProperties({
+      disabled: true
     })
+    this.render(template)
 
-    it('Set parent hook', function () {
-      this.setProperties({
-        selectedTab: tabId,
-        parentHookName: hookName
+    return wait()
+      .then(() => {
+        expect($hook(`${frostTabHook}`)).to.have.length(1)
+        expect($hook(`${frostTabHook}`).find('button.disabled')).to.have.length(1)
       })
-      this.render(hbs`
-        {{frost-tab
-          id=tabId
-          text=tabText
-          selectedTab=selectedTab
-          content= (component 'tab-content' text='Template')
-          targetOutlet=targetOutlet
-          parentHook=parentHookName
-          onChange=onChange
-        }}`)
+  })
 
-      return wait()
-        .then(() => {
-          expect($hook(`${hookName}-${tabId}`)).to.have.length(1)
-          expect($hook(`${hookName}-${tabId}${frostTabHook}`, {selected: true})).to.have.length(1)
-          expect($hook(`${hookName}-${tabId}${frostTabHook}`, {selected: true}).find('button.active')).to.have.length(1)
-        })
+  it('Set parent hook', function () {
+    this.setProperties({
+      selectedTab: tabId,
+      hookName: hookName
     })
+    this.render(template)
 
-    it('Set classes', function () {
-      this.setProperties({
-        selectedTab: tabId,
-        classNames: 'my-class'
+    return wait()
+      .then(() => {
+        expect($hook(`${hookName}${frostTabHook}`, {selected: true})).to.have.length(1)
+        expect($hook(`${hookName}${frostTabHook}`, {selected: true}).find('button.active')).to.have.length(1)
       })
-      this.render(template)
-      return wait()
-        .then(() => {
-          expect($('.my-class')).to.have.length(1)
-        })
+  })
+
+  it('Set parent hook', function () {
+    this.setProperties({
+      selectedTab: tabId,
+      parentHookName: hookName
     })
-  }
-)
+    this.render(hbs`
+      {{frost-tab
+        id=tabId
+        text=tabText
+        selectedTab=selectedTab
+        content= (component 'tab-content' text='Template')
+        targetOutlet=targetOutlet
+        parentHook=parentHookName
+        onChange=onChange
+      }}`)
+
+    return wait()
+      .then(() => {
+        expect($hook(`${hookName}-${tabId}`)).to.have.length(1)
+        expect($hook(`${hookName}-${tabId}${frostTabHook}`, {selected: true})).to.have.length(1)
+        expect($hook(`${hookName}-${tabId}${frostTabHook}`, {selected: true}).find('button.active')).to.have.length(1)
+      })
+  })
+
+  it('Set classes', function () {
+    this.setProperties({
+      selectedTab: tabId,
+      classNames: 'my-class'
+    })
+    this.render(template)
+    return wait()
+      .then(() => {
+        expect($('.my-class')).to.have.length(1)
+      })
+  })
+})

--- a/tests/integration/components/frost-tabs-test.js
+++ b/tests/integration/components/frost-tabs-test.js
@@ -1,9 +1,8 @@
 import {expect} from 'chai'
 import {$hook, initialize} from 'ember-hook'
-import {describeComponent} from 'ember-mocha'
 import wait from 'ember-test-helpers/wait'
 import hbs from 'htmlbars-inline-precompile'
-import {beforeEach, it} from 'mocha'
+import {beforeEach, describe, it} from 'mocha'
 
 const frostTabsTabHook = '-tab'
 const hookName = 'my-hook'
@@ -40,95 +39,93 @@ const template = hbs`
   }}
 `
 
-describeComponent(
-  'frost-tabs',
-  'Integration: FrostTabsComponent',
-  {
-    integration: true
-  },
-  function () {
-    beforeEach(function () {
-      initialize()
-      this.setProperties({
-        hookName,
-        templateTabId,
-        controllerTabId,
-        templateTabText,
-        controllerTabText
-      })
-      this.on('tabSelected', function (tab) {
-        this.set('selectedTab', tab)
-      })
+import {integration} from 'dummy/tests/helpers/ember-test-utils/setup-component-test'
+
+const test = integration('frost-tabs')
+describe(test.label, function () {
+  test.setup()
+
+  beforeEach(function () {
+    initialize()
+    this.setProperties({
+      hookName,
+      templateTabId,
+      controllerTabId,
+      templateTabText,
+      controllerTabText
     })
+    this.on('tabSelected', function (tab) {
+      this.set('selectedTab', tab)
+    })
+  })
 
-    it('Renders', function (done) {
-      this.setProperties({
-        selectedTab: templateTabId
-      })
-      this.render(template)
+  it('Renders', function (done) {
+    this.setProperties({
+      selectedTab: templateTabId
+    })
+    this.render(template)
 
-      return wait()
-        .then(() => {
-          expect($hook(`${hookName}${frostTabsTabHook}`, {index: 0})).to.have.length(1)
-          expect($hook(`${hookName}${frostTabsTabHook}`, {index: 0}).find('button.active')).to.have.length(1)
+    return wait()
+      .then(() => {
+        expect($hook(`${hookName}${frostTabsTabHook}`, {index: 0})).to.have.length(1)
+        expect($hook(`${hookName}${frostTabsTabHook}`, {index: 0}).find('button.active')).to.have.length(1)
 
-          return capture('frost-tabs', done, {
-            experimentalSvgs: true
-          })
+        return capture('frost-tabs', done, {
+          experimentalSvgs: true
         })
-    })
-
-    it('Default selected tab', function () {
-      this.render(template)
-
-      return wait()
-        .then(() => {
-          expect($hook(`${hookName}${frostTabsTabHook}`, {index: 0}).find('button.active')).to.have.length(0)
-          expect($hook(`${hookName}${frostTabsTabHook}`, {index: 1}).find('button.active')).to.have.length(0)
-          expect($hook(`${hookName}${frostTabsTabHook}`, {index: 2}).find('button.active')).to.have.length(0)
-          expect($hook('-tab-content').text().trim()).to.equal('')
-        })
-    })
-
-    it('Selected tab', function () {
-      this.setProperties({
-        selectedTab: controllerTabId
       })
-      this.render(template)
+  })
 
-      return wait()
-        .then(() => {
-          expect($hook(`${hookName}-tab-content`).text().trim()).to.be.equal(controllerTabText)
-        })
-    })
+  it('Default selected tab', function () {
+    this.render(template)
 
-    it('Set hook', function () {
-      this.setProperties({
-        selectedTab: templateTabId,
-        hookName: hookName
+    return wait()
+      .then(() => {
+        expect($hook(`${hookName}${frostTabsTabHook}`, {index: 0}).find('button.active')).to.have.length(0)
+        expect($hook(`${hookName}${frostTabsTabHook}`, {index: 1}).find('button.active')).to.have.length(0)
+        expect($hook(`${hookName}${frostTabsTabHook}`, {index: 2}).find('button.active')).to.have.length(0)
+        expect($hook('-tab-content').text().trim()).to.equal('')
       })
-      this.render(template)
+  })
 
-      return wait()
-        .then(() => {
-          expect($hook(`${hookName}${frostTabsTabHook}`, {index: 0})).to.have.length(1)
-          expect($hook(`${hookName}-${templateTabId}`)).to.have.length(1)
-          expect($hook(`${hookName}-${templateTabId}-tab`, {selected: true})).to.have.length(1)
-          expect($hook(`${hookName}${frostTabsTabHook}`, {index: 0}).find('button.active')).to.have.length(1)
-        })
+  it('Selected tab', function () {
+    this.setProperties({
+      selectedTab: controllerTabId
     })
+    this.render(template)
 
-    it('Set classes', function () {
-      this.setProperties({
-        selectedTab: templateTabId,
-        classNames: 'my-class'
+    return wait()
+      .then(() => {
+        expect($hook(`${hookName}-tab-content`).text().trim()).to.be.equal(controllerTabText)
       })
-      this.render(template)
+  })
 
-      return wait()
-        .then(() => {
-          expect($('.my-class')).to.have.length(1)
-        })
+  it('Set hook', function () {
+    this.setProperties({
+      selectedTab: templateTabId,
+      hookName: hookName
     })
-  }
-)
+    this.render(template)
+
+    return wait()
+      .then(() => {
+        expect($hook(`${hookName}${frostTabsTabHook}`, {index: 0})).to.have.length(1)
+        expect($hook(`${hookName}-${templateTabId}`)).to.have.length(1)
+        expect($hook(`${hookName}-${templateTabId}-tab`, {selected: true})).to.have.length(1)
+        expect($hook(`${hookName}${frostTabsTabHook}`, {index: 0}).find('button.active')).to.have.length(1)
+      })
+  })
+
+  it('Set classes', function () {
+    this.setProperties({
+      selectedTab: templateTabId,
+      classNames: 'my-class'
+    })
+    this.render(template)
+
+    return wait()
+      .then(() => {
+        expect($('.my-class')).to.have.length(1)
+      })
+  })
+})


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [ ] #patch# - backwards-compatible bug fix
 - [X] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

Closes: https://github.com/ciena-frost/ember-frost-tabs/issues/41

# CHANGELOG

* **Updated** integration tests to remove the deprecated use of `describeComponent()`
* **Added** `ember-test-utils` dependency for usage in testing
