### PR TITLE
Update to new linting functionality

### DIFF
--- a/.remarkrc
+++ b/.remarkrc
@@ -1,0 +1,11 @@
+{
+  "plugins": {
+    "lint": {
+      "list-item-indent": false,
+      "maximum-line-length": 119
+    }
+  },
+  "settings": {
+    "commonmark": true
+  }
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: required
 dist: trusty
 language: node_js
 node_js:
-- '5.0'
+- '6.9'
 - 'stable'
 branches:
   except:

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ deploy:
     branch: master
     condition: "$EMBER_TRY_SCENARIO = 'default'"
     node: 'stable'
-    tags: false
+    tags: true
 after_deploy:
 - .travis/publish-gh-pages.sh
 notifications:

--- a/README.md
+++ b/README.md
@@ -53,10 +53,12 @@ Detailed API and example usage can be found in the sample application in `tests/
 
 ### Ember-elsewhere
 
-This addon uses the [ember-elsewhere](https://github.com/ef4/ember-elsewhere) to manage the tabs, to put the tab in the right location
+This addon uses the [ember-elsewhere](https://github.com/ef4/ember-elsewhere) to manage the tabs, to put the tab
+in the right location
 
 ### Testing with ember-hook
-This addon has been optimized for use with [ember-hook](https://github.com/Ticketfly/ember-hook). You can set a `hook` name on your tabs template. 
+This addon has been optimized for use with [ember-hook](https://github.com/Ticketfly/ember-hook). You can set a `hook`
+name on your tabs template.
 This will allow you to access the internal tabs content for testing.
 
 ## Development

--- a/package.json
+++ b/package.json
@@ -8,13 +8,10 @@
     "test": "tests"
   },
   "scripts": {
-    "start": "ember server",
     "build": "ember build",
-    "test": "npm run lint && COVERAGE=true ember test",
-    "lint": "npm run eslint && npm run sass-lint && npm run md-lint",
-    "md-lint": "remark *.md",
-    "eslint": "eslint *.js addon app config tests",
-    "sass-lint": "sass-lint -q -v"
+    "lint": "lint-all-the-things",
+    "start": "ember server",
+    "test": "npm run lint && COVERAGE=true ember test"
   },
   "repository": "git@github.com:ciena-frost/ember-frost-tabs.git",
   "engines": {
@@ -58,14 +55,9 @@
     "ember-simple-uuid": "0.1.4",
     "ember-sinon": "0.6.0",
     "ember-spread": "^1.1.1",
-    "ember-test-utils": "^1.7.0",
+    "ember-test-utils": "^1.10.7",
     "ember-truth-helpers": "^1.3.0",
-    "eslint": "^3.14.0",
-    "eslint-config-frost-standard": "^5.3.2",
-    "loader.js": "^4.1.0",
-    "remark-cli": "^2.1.0",
-    "remark-lint": "^5.4.0",
-    "sass-lint": "^1.10.2"
+    "loader.js": "^4.1.0"
   },
   "keywords": [
     "ember-addon",


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [X] #patch# - backwards-compatible bug fix
 - [ ] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

Closes: https://github.com/ciena-frost/ember-frost-tabs/issues/44

# CHANGELOG
* **Updated** Travis to only publish when git tags are added in preparation for non-version bump pull requests.
* **Updated** linting to use linting tools from `ember-test-utils`.