### PR TITLE
Upgrade ember-cli to 2.12.3

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,0 @@
-{
-  "extends": ["frost-standard"],
-  "globals": {
-    "capture": false
-  }
-}

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,6 @@
+module.exports = {
+  extends: 'frost-standard',
+  globals: {
+    capture: false
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# See http://help.github.com/ignore-files/ for more about ignoring files.
+# See https://help.github.com/ignore-files/ for more about ignoring files.
 
 # compiled output
 /dist
@@ -13,7 +13,7 @@
 /connect.lock
 /coverage/*
 /libpeerconnection.log
-npm-debug.log
+npm-debug.log*
 testem.log
 .idea
 coverage.json

--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,5 @@
 bower_components/
-config/
+config/ember-try.js
 tests/
 tmp/
 dist/
@@ -7,7 +7,7 @@ dist/
 .editorconfig
 .ember-cli
 .eslintignore
-.eslintrc
+.eslintrc.js
 .github
 .pullapprove.yml
 .sass-lint.yml
@@ -22,6 +22,6 @@ ember-cli-build.js
 Brocfile.js
 dependency-snapshot.json
 jsconfig.js
-testem.json
+testem.js
 .idea
 /visual-acceptance

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ matrix:
   fast_finish: true
   allow_failures:
   - env: EMBER_TRY_SCENARIO=ember-release
+  - node_js: 'stable'
 
 before_install:
 - npm config set spin false

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,8 @@ cache:
 
 env:
   matrix:
-  - EMBER_TRY_SCENARIO=ember-2-8
-  - EMBER_TRY_SCENARIO=default
-  - EMBER_TRY_SCENARIO=ember-release
+  - EMBER_TRY_SCENARIO=ember-lts-2.8
+  - EMBER_TRY_SCENARIO=ember-default
   global:
     - CXX=g++-4.8
     - secure: DpNOb8ExJYygQn8cIq5pZria/SkmbFerD3PUWUNSbzYRlF5PsAd9rCH1MeigNykM69kaeE/ZXUPzxj/MG3cgsNpHvp7wFWP+FSra1IOJ485LWS87gTSlmFP71uXtIZThO4O/04gerItNXmoROhQKgCE6NtJCCo3UhPkHbFcsiIINgdI5V/T/CVAU5PKuVmnnGQUy9DtRnqxnp4OuFOXyaa1RpB7SkuulnSyZ3q7kPx0iVUaCY2UQ+h4mLLO+BNfRSjZn/3NzOdwu5TXb7zs6WJI4CmixJn306a7fpcaxpItoCWgo2PuMpsT8oySBbmPbpAJc8WZdJI+WgVwFf86U+ZI+g9so9IIt/89xt9w4xJQHIPcMOBORmAFw0EDYFm5hzM0gll162FTMzWdFr71P28V4mXlMtXrcl0UXnevX6ME6S/OmsPCId8BJVr2GnrwcKPiIPdq3WinKMLcqPsxcR7/KP3m/8Yq293RSwZ1Cnifrn/+usoqJ6TgzOsmIJcmKdyoaNtgeNxES+IqrGowyLnIQWilbPqzSSmKJ1kWaYT9GrslpAgB43VcFd7D6NApPPCTceUrP0ES61PF51b5GvhNr6SvJpf29uqWjr9qZRxKxn6f0/H6Rdz2P1KWaq8MCKWjgcxYwa+yV4BurXwNu1fzQfnIWdtmGgzdmQ2C4zEA=
@@ -63,7 +62,7 @@ deploy:
     secure: acpQg1sXMfIYa620gxKtZFD8nLZKNripDvtFgdVL5aojABE4PjBVt0+GfaMEb5Nz5Kliy2YwLFiGi8m7a4jtAF6kUe31Cmv8TyTd3klhSHCm/E65cU+/erXbJjDJN/NO7mpcq3h76lqHPdA8otwhHF/jZKi7UMu4DtwoFuQ64GxlJZjuiHGIGQVsmkj37LaKbgox4j6rvyB/OngAkdtjUo98+3/KRe5DyPWgvqyaOpemfsIsQD8CSdpNPH/+N0zx46dvSS6Uyb7xlv1Xpf5V+BTKoMXhkw9gXPQl7GyyE85z6uMhComUmgL6gzimv4PDZcs3xQWuZWHyG17JW5Zt3h/VX9E5WQqfa3F3vCPKLo0ENI3mbbhnmiVaMwi39JQUEI4j9sd0JxMcqgGcLQR6AQtTUHBGK6HbkDfe7D2g1x5ujGj7Dc0IsED19EEkR+ER3n76IesEF3XBdqtQd6xr3ojsaL32K+c0RWvgiA15CG6K4YhVAE4GZDyADmXp9JimFwEP+RiUBTJIIcpTeRdeoFN4CXWZsjvZciwY87TF1ab5uolb3WHtinZGjb7X/+BWxv7+yG2waKkh7kNcgsa4c991wWT7r5KSQXPzvT6J1ozwg2AWlvaqvFqNgaH8T/CtaeJ88opV3A3OCVCskJHJYTgYQUS4gAgffGkh8FQ8fAQ=
   on:
     all_branches: true
-    condition: "$EMBER_TRY_SCENARIO = 'default'"
+    condition: "$EMBER_TRY_SCENARIO = 'ember-default'"
     node: '6.9.1'
     tags: true
 

--- a/.travis/maybe-bump-version.sh
+++ b/.travis/maybe-bump-version.sh
@@ -6,7 +6,7 @@ then
   exit 0
 fi
 
-if [ "$EMBER_TRY_SCENARIO" != "default" ]
+if [ "$EMBER_TRY_SCENARIO" != "ember-default" ]
 then
   echo "Skipping version bump for EMBER_TRY_SCENARIO ${EMBER_TRY_SCENARIO}"
   exit 0

--- a/.travis/maybe-publish-coverage.sh
+++ b/.travis/maybe-publish-coverage.sh
@@ -14,7 +14,7 @@ then
   exit 0
 fi
 
-if [ "$EMBER_TRY_SCENARIO" != "default" ]
+if [ "$EMBER_TRY_SCENARIO" != "ember-default" ]
 then
   echo "Skipping coverage publish for EMBER_TRY_SCENARIO ${EMBER_TRY_SCENARIO}"
   exit 0

--- a/bower.json
+++ b/bower.json
@@ -1,8 +1,6 @@
 {
   "name": "ember-frost-tabs",
   "dependencies": {
-    "ember": "~2.11.0",
-    "ember-cli-shims": "^0.1.0",
     "Faker": "^3.0.1",
     "pretender": "^0.10.1",
     "node-uuid": "1.4.7",

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -1,151 +1,36 @@
+/* eslint-env node */
+
 module.exports = {
   scenarios: [
     {
-      name: 'default',
-      bower: {
-        dependencies: { }
-      }
-    },
-    {
-      name: 'ember-1-12',
+      name: 'ember-lts-2.8',
       bower: {
         dependencies: {
-          'ember': '~1.12.0'
+          'ember': 'components/ember#lts-2-8'
         },
         resolutions: {
-          'ember': '~1.12.0'
+          'ember': 'lts-2-8'
+        }
+      },
+      npm: {
+        devDependencies: {
+          'ember-source': null
         }
       }
     },
     {
-      name: 'ember-1-13',
+      name: 'ember-lts-2.12',
       bower: {
         dependencies: {
-          'ember': '~1.13.0'
+          'ember': 'components/ember#lts-2-12'
         },
         resolutions: {
-          'ember': '~1.13.0'
+          'ember': 'lts-2-12'
         }
-      }
-    },
-    {
-      name: 'ember-2-0',
-      bower: {
-        dependencies: {
-          'ember': '~2.0.0'
-        },
-        resolutions: {
-          'ember': '~2.0.0'
-        }
-      }
-    },
-    {
-      name: 'ember-2-1',
-      bower: {
-        dependencies: {
-          'ember': '~2.1.0'
-        },
-        resolutions: {
-          'ember': '~2.1.0'
-        }
-      }
-    },
-    {
-      name: 'ember-2-2',
-      bower: {
-        dependencies: {
-          'ember': '~2.2.0'
-        },
-        resolutions: {
-          'ember': '~2.2.0'
-        }
-      }
-    },
-    {
-      name: 'ember-2-3',
-      bower: {
-        dependencies: {
-          'ember': '~2.3.0'
-        },
-        resolutions: {
-          'ember': '~2.3.0'
-        }
-      }
-    },
-    {
-      name: 'ember-2-4',
-      bower: {
-        dependencies: {
-          'ember': '~2.4.0'
-        },
-        resolutions: {
-          'ember': '~2.4.0'
-        }
-      }
-    },
-    {
-      name: 'ember-2-5',
-      bower: {
-        dependencies: {
-          'ember': '~2.5.0'
-        },
-        resolutions: {
-          'ember': '~2.5.0'
-        }
-      }
-    },
-    {
-      name: 'ember-2-6',
-      bower: {
-        dependencies: {
-          'ember': '~2.6.0'
-        },
-        resolutions: {
-          'ember': '~2.6.0'
-        }
-      }
-    },
-    {
-      name: 'ember-2-7',
-      bower: {
-        dependencies: {
-          'ember': '~2.7.0'
-        },
-        resolutions: {
-          'ember': '~2.7.0'
-        }
-      }
-    },
-    {
-      name: 'ember-2-8',
-      bower: {
-        dependencies: {
-          'ember': '~2.8.0'
-        },
-        resolutions: {
-          'ember': '~2.8.0'
-        }
-      }
-    },
-    {
-      name: 'ember-2-9',
-      bower: {
-        dependencies: {
-          'ember': '~2.9.0'
-        },
-        resolutions: {
-          'ember': '~2.9.0'
-        }
-      }
-    },
-    {
-      name: 'ember-2-10',
-      bower: {
-        dependencies: {
-          'ember': '~2.01.0'
-        },
-        resolutions: {
-          'ember': '~2.10.0'
+      },
+      npm: {
+        devDependencies: {
+          'ember-source': null
         }
       }
     },
@@ -158,6 +43,11 @@ module.exports = {
         resolutions: {
           'ember': 'release'
         }
+      },
+      npm: {
+        devDependencies: {
+          'ember-source': null
+        }
       }
     },
     {
@@ -168,6 +58,11 @@ module.exports = {
         },
         resolutions: {
           'ember': 'beta'
+        }
+      },
+      npm: {
+        devDependencies: {
+          'ember-source': null
         }
       }
     },
@@ -180,6 +75,17 @@ module.exports = {
         resolutions: {
           'ember': 'canary'
         }
+      },
+      npm: {
+        devDependencies: {
+          'ember-source': null
+        }
+      }
+    },
+    {
+      name: 'ember-default',
+      npm: {
+        devDependencies: {}
       }
     }
   ]

--- a/config/environment.js
+++ b/config/environment.js
@@ -1,3 +1,5 @@
+/* eslint-env node */
+
 'use strict'
 
 module.exports = function (/* environment, appConfig */) {

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -1,8 +1,8 @@
-/* global require, module */
-var EmberApp = require('ember-cli/lib/broccoli/ember-addon')
+/* eslint-env node */
+const EmberAddon = require('ember-cli/lib/broccoli/ember-addon')
 
 module.exports = function (defaults) {
-  var app = new EmberApp(defaults, {
+  var app = new EmberAddon(defaults, {
     'ember-cli-mocha': {
       useLintTree: false
     },

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-/* globals module */
+/* eslint-env node */
 
 'use strict'
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lint": "lint-all-the-things",
     "start": "ember server",
     "test": "npm run lint && npm run test-addon",
-    "test-addon": "EMBER_TRY_SCENARIO=${EMBER_TRY_SCENARIO:=default} && ember try:one $EMBER_TRY_SCENARIO --- ember tva --push-var='false' COVERAGE=true --msg-on=$EMBER_TRY_SCENARIO"
+    "test-addon": "EMBER_TRY_SCENARIO=${EMBER_TRY_SCENARIO:=ember-default} && ember try:one $EMBER_TRY_SCENARIO --- ember tva --push-var='false' COVERAGE=true --msg-on=$EMBER_TRY_SCENARIO"
   },
   "repository": "git@github.com:ciena-frost/ember-frost-tabs.git",
   "engines": {
@@ -29,43 +29,43 @@
   ],
   "license": "MIT",
   "devDependencies": {
-    "broccoli-asset-rev": "^2.5.0",
-    "ember-cli": "~2.11.0",
+    "broccoli-asset-rev": "^2.4.5",
+    "ember-cli": "2.12.3",
     "ember-cli-chai": "0.3.2",
     "ember-cli-code-coverage": "0.3.5",
     "ember-cli-dependency-checker": "^1.3.0",
     "ember-cli-htmlbars-inline-precompile": "0.3.6",
-    "ember-cli-inject-live-reload": "^1.6.1",
+    "ember-cli-inject-live-reload": "^1.4.1",
     "ember-cli-mocha": "0.13.2",
     "ember-cli-notifications": "^4.1.6",
+    "ember-cli-shims": "^1.0.2",
     "ember-cli-template-lint": "0.5.2",
-    "ember-cli-test-loader": "^1.1.1",
     "ember-cli-uglify": "^1.2.0",
     "ember-cli-visual-acceptance": "^2.2.0",
     "ember-code-snippet": "^1.8.0",
     "ember-computed-decorators": "0.3.0",
     "ember-concurrency": "0.7.19",
     "ember-disable-prototype-extensions": "^1.1.0",
-    "ember-disable-proxy-controllers": "^1.0.1",
     "ember-elsewhere": "0.4.1",
-    "ember-export-application-global": "^1.1.1",
+    "ember-export-application-global": "^1.0.5",
     "ember-hook": "^1.4.1",
-    "ember-load-initializers": "0.6.3",
+    "ember-load-initializers": "^0.6.0",
     "ember-prop-types": "^3.10.2",
     "ember-resolver": "^2.1.1",
     "ember-sinon": "0.6.0",
+    "ember-source": "~2.12.0",
     "ember-spread": "^1.1.1",
     "ember-test-utils": "^1.10.7",
     "ember-truth-helpers": "^1.3.0",
-    "loader.js": "^4.1.0"
+    "loader.js": "^4.2.3"
   },
   "keywords": [
     "ember-addon",
     "frost"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.1.5",
-    "ember-cli-htmlbars": "^1.0.1",
+    "ember-cli-babel": "^5.1.7",
+    "ember-cli-htmlbars": "^1.1.1",
     "ember-cli-sass": "^5.1.0",
     "ember-frost-core": "^1.14.3",
     "ember-simple-uuid": "0.1.4"

--- a/testem.js
+++ b/testem.js
@@ -1,3 +1,5 @@
+/* eslint-env node */
+
 var Reporter = require('ember-test-utils/reporter')
 
 module.exports = {

--- a/tests/.eslintrc
+++ b/tests/.eslintrc
@@ -1,8 +1,0 @@
-{
-  "globals": {
-    "$": true,
-    "chai": true,
-    "Ember": true,
-    "sinon": true
-  }
-}

--- a/tests/.eslintrc.js
+++ b/tests/.eslintrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+  env: {
+    embertest: true
+  }
+}

--- a/tests/dummy/app/resolver.js
+++ b/tests/dummy/app/resolver.js
@@ -1,0 +1,3 @@
+import Resolver from 'ember-resolver'
+
+export default Resolver

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -1,12 +1,18 @@
+/* eslint-env node */
+
 module.exports = function (environment) {
   var ENV = {
     modulePrefix: 'dummy',
     podModulePrefix: 'dummy/pods',
     environment: environment,
     rootURL: '/',
-    locationType: 'auto',
+    locationType: 'hash',
     EmberENV: {
-      FEATURES: {}
+      FEATURES: {},
+      EXTEND_PROTOTYPES: {
+        // Prevent Ember Data from overriding Date.parse.
+        Date: false
+      }
     },
 
     APP: {},
@@ -19,7 +25,6 @@ module.exports = function (environment) {
 
   if (environment === 'test') {
     // Testem prefers this...
-    ENV.rootURL = '/'
     ENV.locationType = 'none'
 
     // keep test console output quieter

--- a/tests/helpers/start-app.js
+++ b/tests/helpers/start-app.js
@@ -5,16 +5,13 @@ import Application from '../../app'
 import config from '../../config/environment'
 
 export default function startApp (attrs) {
-  let application
-
   let attributes = merge({}, config.APP)
   attributes = merge(attributes, attrs) // use defaults, but you can override;
 
-  run(() => {
-    application = Application.create(attributes)
+  return run(() => {
+    let application = Application.create(attributes)
     application.setupForTesting()
     application.injectTestHelpers()
+    return application
   })
-
-  return application
 }

--- a/tests/index.html
+++ b/tests/index.html
@@ -21,10 +21,10 @@
 
     {{content-for 'body'}}
     {{content-for 'test-body'}}
+    <script src="/testem.js" integrity=""></script>
     <script src="{{rootURL}}assets/vendor.js"></script>
     <script src="{{rootURL}}assets/test-support.js"></script>
     <script src="{{rootURL}}assets/dummy.js"></script>
-    <script src="{{rootURL}}testem.js" integrity=""></script>
     <script src="{{rootURL}}assets/tests.js"></script>
 
     {{content-for 'body-footer'}}

--- a/tests/integration/components/frost-tab-test.js
+++ b/tests/integration/components/frost-tab-test.js
@@ -1,8 +1,11 @@
 import {expect} from 'chai'
+import Ember from 'ember'
 import {$hook, initialize} from 'ember-hook'
 import wait from 'ember-test-helpers/wait'
 import hbs from 'htmlbars-inline-precompile'
 import {beforeEach, describe, it} from 'mocha'
+
+const {$} = Ember
 
 const frostTabHook = '-tab'
 const hookName = 'my-hook'

--- a/tests/integration/components/frost-tabs-test.js
+++ b/tests/integration/components/frost-tabs-test.js
@@ -1,8 +1,11 @@
 import {expect} from 'chai'
+import Ember from 'ember'
 import {$hook, initialize} from 'ember-hook'
 import wait from 'ember-test-helpers/wait'
 import hbs from 'htmlbars-inline-precompile'
 import {beforeEach, describe, it} from 'mocha'
+
+const {$} = Ember
 
 const frostTabsTabHook = '-tab'
 const hookName = 'my-hook'


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG
* Upgrade `ember-cli` to `2.12.3`