### PR TITLE
Refactor to remove need for ember-simple-uuid dependency

### DIFF
--- a/addon/components/frost-tabs.js
+++ b/addon/components/frost-tabs.js
@@ -1,8 +1,7 @@
 import Ember from 'ember'
-const {Component} = Ember
+const {Component, guidFor} = Ember
 import layout from '../templates/components/frost-tabs'
 import PropTypesMixin, {PropTypes} from 'ember-prop-types'
-import uuid from 'ember-simple-uuid'
 
 export default Component.extend(PropTypesMixin, {
   // == Component properties ==================================================
@@ -25,7 +24,7 @@ export default Component.extend(PropTypesMixin, {
   getDefaultProps () {
     return {
       design: 'horizontal',
-      targetOutlet: `frost-tab-content-${uuid()}`
+      targetOutlet: `frost-tab-content-${guidFor({})}`
     }
   }
 })

--- a/blueprints/ember-frost-tabs/index.js
+++ b/blueprints/ember-frost-tabs/index.js
@@ -6,8 +6,7 @@ module.exports = {
 
   afterInstall: function (options) {
     const addonsToAdd = [
-      {name: 'ember-frost-core', target: '^3.0.1'},
-      {name: 'ember-simple-uuid', target: '0.1.4'}
+      {name: 'ember-frost-core', target: '^3.0.1'}
     ]
 
     // Get the packages installed in the consumer app/addon. Packages that are already installed in the consumer within

--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,6 @@
   "dependencies": {
     "Faker": "^3.0.1",
     "pretender": "^0.10.1",
-    "node-uuid": "1.4.7",
     "ember-mocha-adapter": "~0.3.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -71,8 +71,7 @@
     "ember-cli-babel": "^5.1.7",
     "ember-cli-htmlbars": "^1.1.1",
     "ember-cli-sass": "5.6.0",
-    "ember-frost-core": "^3.0.1",
-    "ember-simple-uuid": "0.1.4"
+    "ember-frost-core": "^3.0.1"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG
* Refactor to remove need for `ember-simple-uuid` dependency