### PR TITLE
Change semver range of ember-load-initializers

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "ember-export-application-global": "^1.0.5",
     "ember-frost-info-bar": "8.3.5",
     "ember-hook": "^1.4.1",
-    "ember-load-initializers": "0.6.3",
+    "ember-load-initializers": "^0.6.0",
     "ember-math-helpers": "2.1.0",
     "ember-prop-types": "^3.10.2",
     "ember-resolver": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   ],
   "license": "MIT",
   "devDependencies": {
+    "bower": "^1.8.2",
     "broccoli-asset-rev": "^2.4.5",
     "chai-jquery": "^2.0.0",
     "ember-cli": "2.12.3",


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG
* Change semver range of `ember-load-initializers` to align with other repos